### PR TITLE
Fixed deprecation error within regex

### DIFF
--- a/twitter.php
+++ b/twitter.php
@@ -352,7 +352,7 @@ Class atomic_api
 	{
 
 	  //Convert urls to <a> links
-	  $tweet = preg_replace("/([\w]+\:\/\/[\w-?&;#~=\.\/\@]+[\w\/])/", "<a target=\"_blank\" href=\"$1\">$1</a>", $tweet);
+	  $tweet = preg_replace("/([\w]+\:\/\/[\w\-?&;#~=\.\/\@]+[\w\/])/", "<a target=\"_blank\" href=\"$1\">$1</a>", $tweet);
 
 	  //Convert hashtags to twitter searches in <a> links
 	  $tweet = preg_replace("/#([A-Za-z0-9\/\.]*)/", "<a target=\"_new\" href=\"http://twitter.com/search?q=$1\">#$1</a>", $tweet);


### PR DESCRIPTION
Stopped a possible deprecation error on PHP 7.4 and above

* Changed the `[\w-` to `[\w\-`